### PR TITLE
Add ⌘K command-palette navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 # generated files
 public/rss-feed.xml
 public/sitemap.xml
+public/search-index.json
 
 .idea
 .eslintcache

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -40,8 +40,27 @@ Shared domain types are in `lib/types.ts`. Three dead files were left as
 excluded: Next require()s it at process start, before any transpiler is
 loaded.
 
-## 3. Cmd-K style navigation
+## 3. Cmd-K style navigation (done)
 
-Add a command-palette (⌘K) navigation for jumping to posts, pages, and
-projects. Needs a search index over markdown content and a keyboard-driven UI
-consistent with the site's bundle-size goals.
+⌘K / Ctrl-K opens a hand-rolled, zero-dependency command palette
+(`components/CommandPalette.tsx`) for jumping to posts, pages, and meet
+reports; a search button in the header is the trigger on touch devices. It
+searches titles + metadata (not body text) against a build-time index
+(`scripts/generate-search-index.ts` → `public/search-index.json`, ~3.6 KB gz,
+gitignored) built from the `lib/blogs.ts` getters (so drafts are excluded)
+plus a curated page list; the shared item schema lives in
+`lib/searchIndex.ts`. Index generation runs in both `npm run build` and
+`npm run export`. Bundle cost: +~0.6 KB gz on the shared `_app` chunk (keydown
+listener + header button + lazy mount); the palette itself is a ~2.5 KB gz
+async chunk, prefetched on first idle and on header-button hover, with the
+index fetched once and cached. `next/dynamic` was deliberately avoided — its
+loadable runtime added ~1.7 KB gz to `_app`; a small hand-rolled
+`import()`-in-effect mount replaced it. Follow-ups worth tracking:
+
+- Tag pages are not in the index (deliberate). If they're added, fix the
+  untrimmed-tags bug first: `pages/tag/[tag].tsx` splits `tags` on `","`
+  without trimming, so the export contains duplicate `out/tag/ code/`-style
+  directories for the three posts with spaces after commas.
+- No `description` frontmatter exists, so entries are title + date only; the
+  RSS excerpt machinery (`markdownToHtml().excerpt`) is available if palette
+  entries ever want subtitles.

--- a/assets/search.svg
+++ b/assets/search.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24" width="24" height="24" preserveAspectRatio="xMinYMin"><path d="M8 2a6 6 0 1 0 0 12A6 6 0 0 0 8 2zm0 2a4 4 0 1 1 0 8 4 4 0 0 1 0-8zM12.9 11.5l4.4 4.4a1 1 0 0 1-1.4 1.4l-4.4-4.4a6.05 6.05 0 0 0 1.4-1.4z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" preserveAspectRatio="xMinYMin"><path d="M6.5.5a6 6 0 1 0 0 12 6 6 0 0 0 0-12zm0 2.5a3.5 3.5 0 1 1 0 7 3.5 3.5 0 0 1 0-7zM11.62 9.86l3.86 3.86a1.25 1.25 0 0 1-1.76 1.76l-3.86-3.86a6.05 6.05 0 0 0 1.76-1.76z"/></svg>

--- a/assets/search.svg
+++ b/assets/search.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24" width="24" height="24" preserveAspectRatio="xMinYMin"><path d="M8 2a6 6 0 1 0 0 12A6 6 0 0 0 8 2zm0 2a4 4 0 1 1 0 8 4 4 0 0 1 0-8zM12.9 11.5l4.4 4.4a1 1 0 0 1-1.4 1.4l-4.4-4.4a6.05 6.05 0 0 0 1.4-1.4z"/></svg>

--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -1,0 +1,295 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/router";
+
+import { event } from "lib/gtag";
+import { SEARCH_INDEX_PATH } from "lib/searchIndex";
+
+import styles from "styles/components/CommandPalette.module.scss";
+
+import type {
+  SearchIndex,
+  SearchIndexGroup,
+  SearchIndexItem,
+} from "lib/searchIndex";
+
+const MAX_RESULTS = 15;
+const RECENT_POST_COUNT = 5;
+const OPTION_ID_PREFIX = "command-palette-option-";
+
+let indexPromise: Promise<SearchIndex> | null = null;
+
+export function preloadSearchIndex(): Promise<SearchIndex> {
+  if (!indexPromise) {
+    indexPromise = fetch(SEARCH_INDEX_PATH)
+      .then(res => {
+        if (!res.ok) {
+          throw new Error(`Failed to fetch search index: ${res.status}`);
+        }
+        return res.json() as Promise<SearchIndex>;
+      })
+      .catch((err: unknown) => {
+        indexPromise = null;
+        throw err;
+      });
+  }
+  return indexPromise;
+}
+
+// Match tiers: substring (prefix beats mid-string), then title words
+// prefixed by every query word, then in-order character subsequence.
+function score(title: string, query: string): number {
+  const t = title.toLowerCase();
+  const idx = t.indexOf(query);
+  if (idx === 0) return 4;
+  if (idx > 0) return 3;
+
+  const queryWords = query.split(/[^a-z0-9]+/).filter(Boolean);
+  const titleWords = t.split(/[^a-z0-9]+/);
+  if (
+    queryWords.length &&
+    queryWords.every(q => titleWords.some(w => w.startsWith(q)))
+  ) {
+    return 2;
+  }
+
+  let i = 0;
+  for (const c of t) {
+    if (c === query[i]) i++;
+    if (i === query.length) return 1;
+  }
+  return 0;
+}
+
+function matchItems(items: SearchIndexItem[], query: string) {
+  if (!query) {
+    const pages = items.filter(item => item.group === "Pages");
+    const recentPosts = items
+      .filter(item => item.group === "Posts" && item.date)
+      .sort((a, b) => (b.date ?? "").localeCompare(a.date ?? ""))
+      .slice(0, RECENT_POST_COUNT);
+    return [...pages, ...recentPosts];
+  }
+  return items
+    .map((item, order) => ({ item, order, score: score(item.title, query) }))
+    .filter(r => r.score > 0)
+    .sort((a, b) => b.score - a.score || a.order - b.order)
+    .slice(0, MAX_RESULTS)
+    .map(r => r.item);
+}
+
+interface ResultGroup {
+  group: SearchIndexGroup;
+  start: number;
+  items: SearchIndexItem[];
+}
+
+function groupResults(results: SearchIndexItem[]): ResultGroup[] {
+  const groups: ResultGroup[] = [];
+  for (const item of results) {
+    let group = groups.find(g => g.group === item.group);
+    if (!group) {
+      group = { group: item.group, start: 0, items: [] };
+      groups.push(group);
+    }
+    group.items.push(item);
+  }
+  let start = 0;
+  for (const group of groups) {
+    group.start = start;
+    start += group.items.length;
+  }
+  return groups;
+}
+
+function scrollOptionIntoView(el: HTMLDivElement | null) {
+  el?.scrollIntoView({ block: "nearest" });
+}
+
+export interface CommandPaletteProps {
+  onClose: () => void;
+}
+
+export default function CommandPalette({ onClose }: CommandPaletteProps) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [index, setIndex] = useState<SearchIndex | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [selected, setSelected] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const previousFocus = document.activeElement;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    inputRef.current?.focus();
+    event({ action: "command-palette-open", category: "engagement" });
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      if (previousFocus instanceof HTMLElement) {
+        previousFocus.focus();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    preloadSearchIndex()
+      .then(idx => !cancelled && setIndex(idx))
+      .catch(() => !cancelled && setFailed(true));
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const groups = useMemo(
+    () =>
+      groupResults(matchItems(index?.items ?? [], query.trim().toLowerCase())),
+    [index, query],
+  );
+  const flat = useMemo(() => groups.flatMap(g => g.items), [groups]);
+  const selectedIndex = flat.length ? Math.min(selected, flat.length - 1) : -1;
+
+  const navigate = useCallback(
+    (item: SearchIndexItem) => {
+      event({
+        action: "command-palette-select",
+        category: "engagement",
+        label: item.route,
+      });
+      void router.push(item.route);
+      onClose();
+    },
+    [router, onClose],
+  );
+
+  const onQueryChange = useCallback((e: Event) => {
+    setQuery((e.target as HTMLInputElement).value);
+    setSelected(0);
+  }, []);
+
+  const onKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.isComposing) return;
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        if (!flat.length) return;
+        const delta = e.key === "ArrowDown" ? 1 : -1;
+        setSelected(
+          s =>
+            (Math.min(s, flat.length - 1) + delta + flat.length) % flat.length,
+        );
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const item = flat[selectedIndex];
+        if (item) navigate(item);
+      } else if (e.key === "Tab") {
+        e.preventDefault();
+        inputRef.current?.focus();
+      }
+    },
+    [flat, selectedIndex, navigate, onClose],
+  );
+
+  const onPanelMouseDown = useCallback((e: MouseEvent) => {
+    if (e.target !== inputRef.current) {
+      e.preventDefault();
+    }
+  }, []);
+
+  const onBackdropClick = useCallback(
+    (e: MouseEvent) => {
+      if (e.target === e.currentTarget) onClose();
+    },
+    [onClose],
+  );
+
+  return (
+    <div
+      className={styles.overlay}
+      onClick={onBackdropClick}
+      onKeyDown={onKeyDown}
+    >
+      <div
+        className={styles.panel}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Site search"
+        onMouseDown={onPanelMouseDown}
+      >
+        <input
+          ref={inputRef}
+          className={styles.input}
+          type="text"
+          placeholder="Search posts and pages…"
+          value={query}
+          onChange={onQueryChange}
+          role="combobox"
+          aria-expanded="true"
+          aria-autocomplete="list"
+          aria-controls="command-palette-listbox"
+          aria-activedescendant={
+            selectedIndex >= 0
+              ? `${OPTION_ID_PREFIX}${selectedIndex}`
+              : undefined
+          }
+        />
+        <div
+          className={styles.results}
+          role="listbox"
+          id="command-palette-listbox"
+          aria-label="Search results"
+        >
+          {failed && (
+            <div className={styles.status}>Failed to load search index.</div>
+          )}
+          {!failed && !index && <div className={styles.status}>Loading…</div>}
+          {!failed && index && !flat.length && (
+            <div className={styles.status}>No results.</div>
+          )}
+          {groups.map((group, gi) => (
+            <div
+              key={group.group}
+              role="group"
+              aria-labelledby={`command-palette-group-${gi}`}
+            >
+              <div
+                className={styles.groupHeading}
+                id={`command-palette-group-${gi}`}
+              >
+                {group.group}
+              </div>
+              {group.items.map((item, j) => {
+                const i = group.start + j;
+                const isSelected = i === selectedIndex;
+                return (
+                  <div
+                    key={item.route}
+                    id={`${OPTION_ID_PREFIX}${i}`}
+                    role="option"
+                    aria-selected={isSelected}
+                    className={
+                      isSelected
+                        ? `${styles.option} ${styles.optionSelected}`
+                        : styles.option
+                    }
+                    ref={isSelected ? scrollOptionIntoView : undefined}
+                    onMouseMove={() => setSelected(i)}
+                    onClick={() => navigate(item)}
+                  >
+                    <span className={styles.title}>{item.title}</span>
+                    {item.date && (
+                      <span className={styles.date}>{item.date}</span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/CommandPalette.tsx
+++ b/components/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
 import { useRouter } from "next/router";
 
 import { event } from "lib/gtag";
@@ -101,7 +102,7 @@ function groupResults(results: SearchIndexItem[]): ResultGroup[] {
   return groups;
 }
 
-function scrollOptionIntoView(el: HTMLDivElement | null) {
+function scrollOptionIntoView(el: HTMLAnchorElement | null) {
   el?.scrollIntoView({ block: "nearest" });
 }
 
@@ -149,17 +150,24 @@ export default function CommandPalette({ onClose }: CommandPaletteProps) {
   const flat = useMemo(() => groups.flatMap(g => g.items), [groups]);
   const selectedIndex = flat.length ? Math.min(selected, flat.length - 1) : -1;
 
-  const navigate = useCallback(
+  const trackSelect = useCallback(
     (item: SearchIndexItem) => {
       event({
         action: "command-palette-select",
         category: "engagement",
         label: item.route,
       });
-      void router.push(item.route);
       onClose();
     },
-    [router, onClose],
+    [onClose],
+  );
+
+  const navigate = useCallback(
+    (item: SearchIndexItem) => {
+      trackSelect(item);
+      void router.push(item.route);
+    },
+    [router, trackSelect],
   );
 
   const onQueryChange = useCallback((e: Event) => {
@@ -265,11 +273,13 @@ export default function CommandPalette({ onClose }: CommandPaletteProps) {
                 const i = group.start + j;
                 const isSelected = i === selectedIndex;
                 return (
-                  <div
+                  <Link
                     key={item.route}
+                    href={item.route}
                     id={`${OPTION_ID_PREFIX}${i}`}
                     role="option"
                     aria-selected={isSelected}
+                    tabIndex={-1}
                     className={
                       isSelected
                         ? `${styles.option} ${styles.optionSelected}`
@@ -277,13 +287,13 @@ export default function CommandPalette({ onClose }: CommandPaletteProps) {
                     }
                     ref={isSelected ? scrollOptionIntoView : undefined}
                     onMouseMove={() => setSelected(i)}
-                    onClick={() => navigate(item)}
+                    onClick={() => trackSelect(item)}
                   >
                     <span className={styles.title}>{item.title}</span>
                     {item.date && (
                       <span className={styles.date}>{item.date}</span>
                     )}
-                  </div>
+                  </Link>
                 );
               })}
             </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -74,10 +74,7 @@ export default function Header({
           onMouseEnter={onPreloadPalette}
           onFocus={onPreloadPalette}
         >
-          <SearchIcon width={22} height={22} />
-          <kbd className={styles.kbd} aria-hidden="true">
-            ⌘K
-          </kbd>
+          <SearchIcon width={20} height={20} />
         </button>
         <Twitter
           eventAction="header-cta-click"

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,12 +6,21 @@ import { SITE_TITLE } from "lib/constants";
 
 import Image from "components/Image";
 import { Twitter } from "components/Icon";
+import SearchIcon from "assets/search.svg";
 
 import styles from "styles/components/Header.module.scss";
 
 const PROFILE_SIZE = 320;
 
-export default function Header() {
+export interface HeaderProps {
+  onOpenPalette: () => void;
+  onPreloadPalette: () => void;
+}
+
+export default function Header({
+  onOpenPalette,
+  onPreloadPalette,
+}: HeaderProps) {
   const router = useRouter();
   // prevent "auto-prefetch based on viewport... warning"
   const prefetch = router.pathname === "/" ? false : undefined;
@@ -55,6 +64,21 @@ export default function Header() {
         <Link href="/meet-reports" className={styles.link}>
           Meets
         </Link>
+        <button
+          type="button"
+          className={`${styles.link} ${styles.searchButton}`}
+          aria-label="Search"
+          aria-keyshortcuts="Meta+K Control+K"
+          title="Search (⌘K)"
+          onClick={onOpenPalette}
+          onMouseEnter={onPreloadPalette}
+          onFocus={onPreloadPalette}
+        >
+          <SearchIcon width={22} height={22} />
+          <kbd className={styles.kbd} aria-hidden="true">
+            ⌘K
+          </kbd>
+        </button>
         <Twitter
           eventAction="header-cta-click"
           size={25}

--- a/lib/searchIndex.ts
+++ b/lib/searchIndex.ts
@@ -1,0 +1,17 @@
+export type SearchIndexGroup = "Posts" | "Pages" | "Meet reports";
+
+export interface SearchIndexItem {
+  title: string;
+  // Route with trailing slash, e.g. "/posts/foo/"
+  route: string;
+  group: SearchIndexGroup;
+  // ISO date ("YYYY-MM-DD") for dated content; omitted for pages
+  date?: string;
+}
+
+export interface SearchIndex {
+  v: 1;
+  items: SearchIndexItem[];
+}
+
+export const SEARCH_INDEX_PATH = "/search-index.json";

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "node": "24.x"
   },
   "scripts": {
-    "dev": "next dev -p 4000",
-    "build": "node -r @swc-node/register scripts/generate-feeds.ts && next build",
-    "export": "STATIC_EXPORT=1 next build",
+    "dev": "node -r @swc-node/register scripts/generate-search-index.ts && next dev -p 4000",
+    "build": "node -r @swc-node/register scripts/generate-feeds.ts && node -r @swc-node/register scripts/generate-search-index.ts && next build",
+    "export": "node -r @swc-node/register scripts/generate-search-index.ts && STATIC_EXPORT=1 next build",
     "analyze": "ANALYZE=true NODE_ENV=production next build && node -r @swc-node/register scripts/analyze-bundles.ts",
     "start": "next start",
     "prepare": "husky"

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import NProgress from "lib/nprogress";
 import Router, { useRouter } from "next/router";
 import type { AppProps } from "next/app";
+import type { ComponentType } from "react";
+import type { CommandPaletteProps } from "components/CommandPalette";
 
 import "styles/main.scss";
 import { BASE_URL, SITE_TITLE, SITE_DESCRIPTION } from "lib/constants";
@@ -37,13 +39,62 @@ const transitionStyle =
 
 const fullWidthRoutes = ["/metrics"];
 
+// Warms the palette's async chunk and the search-index fetch cache
+function preloadPalette() {
+  void import("components/CommandPalette")
+    .then(mod => mod.preloadSearchIndex())
+    .catch(() => undefined);
+}
+
 function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
   const [loaded, setLoaded] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [Palette, setPalette] =
+    useState<ComponentType<CommandPaletteProps> | null>(null);
+
+  const openPalette = useCallback(() => setPaletteOpen(true), []);
+  const closePalette = useCallback(() => setPaletteOpen(false), []);
 
   useEffect(() => {
     setLoaded(true);
   }, []);
+
+  useEffect(() => {
+    if (!paletteOpen || Palette) return;
+    let cancelled = false;
+    import("components/CommandPalette")
+      .then(mod => !cancelled && setPalette(() => mod.default))
+      .catch((err: unknown) => {
+        console.error("Failed to load command palette", err);
+        if (!cancelled) setPaletteOpen(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [paletteOpen, Palette]);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === "k" || e.key === "K")) {
+        e.preventDefault();
+        if (e.repeat) return;
+        setPaletteOpen(open => !open);
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  useEffect(() => {
+    if (!loaded) return;
+    if (typeof window.requestIdleCallback === "function") {
+      const id = window.requestIdleCallback(preloadPalette);
+      return () => window.cancelIdleCallback(id);
+    }
+    const id = window.setTimeout(preloadPalette, 2000);
+    return () => window.clearTimeout(id);
+  }, [loaded]);
 
   const useFullWidth = fullWidthRoutes.includes(router.pathname);
 
@@ -62,11 +113,12 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <div className="root">
       <Meta {...metas} />
-      <Header />
+      <Header onOpenPalette={openPalette} onPreloadPalette={preloadPalette} />
       <Container>
         <Component {...pageProps} />
       </Container>
       <Footer />
+      {paletteOpen && Palette && <Palette onClose={closePalette} />}
       {loaded && <style>{transitionStyle}</style>}
     </div>
   );

--- a/plugins/next-optimized-classnames.js
+++ b/plugins/next-optimized-classnames.js
@@ -27,6 +27,13 @@ const isFontLoaderChain = use =>
 const webpack = (config, { dev }) => {
   if (dev) return config;
 
+  // The name counter above lives in process memory and restarts at zero each
+  // build, while webpack's persistent filesystem cache replays css-loader
+  // output (generated names included) from prior processes. Mixing the two
+  // assigns the same class name to different modules, so persistent caching
+  // must stay off; the in-build memory cache is per-process and safe.
+  config.cache = { type: "memory" };
+
   let patched = 0;
   for (const { oneOf } of config.module.rules)
     if (Array.isArray(oneOf))

--- a/scripts/compare-bundles.ts
+++ b/scripts/compare-bundles.ts
@@ -53,7 +53,8 @@ const output = `# Bundle Size
 | --- | --- |
 ${sizes}
 
-<!-- GH BOT -->`;
+<!-- GH BOT -->
+`;
 
 try {
   fs.mkdirSync(outdir);

--- a/scripts/generate-search-index.ts
+++ b/scripts/generate-search-index.ts
@@ -1,0 +1,72 @@
+import fs from "fs";
+import { getAllPosts, getAllMeetReports } from "../lib/blogs";
+
+import type {
+  SearchIndex,
+  SearchIndexGroup,
+  SearchIndexItem,
+} from "../lib/searchIndex";
+import type { MarkdownItem } from "../lib/types";
+
+const PAGES: SearchIndexItem[] = [
+  { title: "About", route: "/about/", group: "Pages" },
+  { title: "Projects", route: "/projects/", group: "Pages" },
+  { title: "Archive", route: "/archive/", group: "Pages" },
+  { title: "Meet Reports", route: "/meet-reports/", group: "Pages" },
+  { title: "Impact", route: "/impact/", group: "Pages" },
+  { title: "Metrics", route: "/metrics/", group: "Pages" },
+  { title: "JOTA", route: "/jota/", group: "Pages" },
+  { title: "Track Utilities", route: "/projects/track/", group: "Pages" },
+  {
+    title: "Wind Correction Calculator",
+    route: "/projects/track/wind-correction/",
+    group: "Pages",
+  },
+  {
+    title: "200m Lane Draw Converter",
+    route: "/projects/track/200m-lane-draw/",
+    group: "Pages",
+  },
+  {
+    title: "World Athletics Points Calculator",
+    route: "/projects/track/points-calculator/",
+    group: "Pages",
+  },
+  {
+    title: "100m Predictor",
+    route: "/projects/track/100m-predictor/",
+    group: "Pages",
+  },
+];
+
+function toItem(
+  item: MarkdownItem,
+  group: SearchIndexGroup,
+  routePrefix: string,
+): SearchIndexItem {
+  const { title, slug, date } = item;
+  if (!title || !slug || !date) {
+    throw new Error(
+      `Missing frontmatter for ${group} item: ${JSON.stringify(item)}`,
+    );
+  }
+  return { title, route: `${routePrefix}${slug}/`, group, date };
+}
+
+(function () {
+  const fields = ["title", "date", "slug"];
+
+  const posts = getAllPosts(fields).map(post =>
+    toItem(post, "Posts", "/posts/"),
+  );
+  const meetReports = getAllMeetReports(fields).map(report =>
+    toItem(report, "Meet reports", "/meet-reports/"),
+  );
+
+  const index: SearchIndex = {
+    v: 1,
+    items: posts.concat(PAGES, meetReports),
+  };
+
+  fs.writeFileSync("public/search-index.json", JSON.stringify(index));
+})();

--- a/scripts/generate-search-index.ts
+++ b/scripts/generate-search-index.ts
@@ -8,7 +8,9 @@ import type {
 } from "../lib/searchIndex";
 import type { MarkdownItem } from "../lib/types";
 
-const PAGES: SearchIndexItem[] = [
+// Every static page needs a deliberate decision: list it here, and add its
+// route to EXCLUDED_PAGE_ROUTES if it should stay out of the search palette.
+const ALL_PAGES: SearchIndexItem[] = [
   { title: "About", route: "/about/", group: "Pages" },
   { title: "Projects", route: "/projects/", group: "Pages" },
   { title: "Archive", route: "/archive/", group: "Pages" },
@@ -38,6 +40,26 @@ const PAGES: SearchIndexItem[] = [
     group: "Pages",
   },
 ];
+
+// Listing and utility pages deliberately kept out of the palette. Individual
+// posts and meet reports are indexed under their own groups, so their listing
+// pages add noise rather than value here.
+const EXCLUDED_PAGE_ROUTES = new Set([
+  "/archive/",
+  "/meet-reports/",
+  "/impact/",
+  "/metrics/",
+  "/jota/",
+  "/projects/track/",
+]);
+
+for (const route of EXCLUDED_PAGE_ROUTES) {
+  if (!ALL_PAGES.some(page => page.route === route)) {
+    throw new Error(`Excluded route not present in ALL_PAGES: ${route}`);
+  }
+}
+
+const PAGES = ALL_PAGES.filter(page => !EXCLUDED_PAGE_ROUTES.has(page.route));
 
 function toItem(
   item: MarkdownItem,

--- a/styles/components/CommandPalette.module.scss
+++ b/styles/components/CommandPalette.module.scss
@@ -74,7 +74,7 @@
   align-items: baseline;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.5rem 1rem;
+  padding: 0.4rem 1rem;
   color: var(--dark-gray);
   cursor: pointer;
   text-decoration: none;
@@ -85,7 +85,7 @@
   }
 
   @include mobile {
-    padding: 0.5rem 0.75rem;
+    padding: 0.4rem 0.75rem;
   }
 }
 
@@ -107,6 +107,15 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: 16px;
+  font-weight: bold;
+  letter-spacing: -0.011em;
+  line-height: 1.5;
+
+  @include mobile {
+    font-size: 14px;
+    letter-spacing: -0.006em;
+  }
 }
 
 .date {

--- a/styles/components/CommandPalette.module.scss
+++ b/styles/components/CommandPalette.module.scss
@@ -26,7 +26,6 @@
   font-family: var(--font-face);
   background-color: var(--white);
   border: 2px solid var(--primary-gray);
-  border-radius: 0.25rem;
   box-shadow: var(--shadow-size) var(--shadow-size) 0 0 var(--primary);
 
   @include mobile {
@@ -78,6 +77,12 @@
   padding: 0.5rem 1rem;
   color: var(--dark-gray);
   cursor: pointer;
+  text-decoration: none;
+
+  &:hover,
+  &:active {
+    color: var(--dark-gray);
+  }
 
   @include mobile {
     padding: 0.5rem 0.75rem;
@@ -87,6 +92,11 @@
 .optionSelected {
   background-color: var(--primary);
   color: var(--primary-gray);
+
+  &:hover,
+  &:active {
+    color: var(--primary-gray);
+  }
 
   .date {
     color: var(--primary-gray);

--- a/styles/components/CommandPalette.module.scss
+++ b/styles/components/CommandPalette.module.scss
@@ -1,0 +1,112 @@
+@import "mixins";
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  background-color: rgba(26, 26, 26, 0.55);
+
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 12vh var(--horizontal-margin) 2rem;
+
+  @include mobile {
+    padding-top: 6vh;
+  }
+}
+
+.panel {
+  width: min(36rem, 100%);
+  max-height: 65vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  font-family: var(--font-face);
+  background-color: var(--white);
+  border: 2px solid var(--primary-gray);
+  border-radius: 0.25rem;
+  box-shadow: var(--shadow-size) var(--shadow-size) 0 0 var(--primary);
+
+  @include mobile {
+    max-height: 75vh;
+  }
+}
+
+.input {
+  width: 100%;
+  margin: 0;
+  padding: 0.875rem 1rem;
+  border: 0;
+  border-bottom: 2px solid var(--primary);
+  border-radius: 0;
+  background-color: transparent;
+  color: var(--black);
+  font-family: inherit;
+  font-size: 1rem;
+  outline: none;
+
+  @include mobile {
+    padding: 0.625rem 0.75rem;
+  }
+}
+
+.results {
+  overflow-y: auto;
+  padding: 0.25rem 0 0.5rem;
+}
+
+.groupHeading {
+  padding: 0.625rem 1rem 0.25rem;
+  color: var(--gray);
+  font-size: 0.75rem;
+  font-weight: bold;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+
+  @include mobile {
+    padding: 0.625rem 0.75rem 0.25rem;
+  }
+}
+
+.option {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.5rem 1rem;
+  color: var(--dark-gray);
+  cursor: pointer;
+
+  @include mobile {
+    padding: 0.5rem 0.75rem;
+  }
+}
+
+.optionSelected {
+  background-color: var(--primary);
+  color: var(--primary-gray);
+
+  .date {
+    color: var(--primary-gray);
+  }
+}
+
+.title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.date {
+  flex-shrink: 0;
+  color: var(--gray);
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.status {
+  padding: 1rem;
+  color: var(--gray);
+}

--- a/styles/components/Header.module.scss
+++ b/styles/components/Header.module.scss
@@ -67,33 +67,20 @@
 .searchButton {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
   margin: 0;
   padding: 0;
   border: 0;
   background: none;
-  font-family: inherit;
   cursor: pointer;
 
   &:hover,
   &:active,
   &:focus-visible {
-    color: var(--primary);
     fill: var(--primary);
   }
-}
 
-.kbd {
-  font-family: inherit;
-  font-size: 12px;
-  font-weight: bold;
-  line-height: 1;
-  padding: 0.2rem 0.3rem;
-  border: 1px solid currentColor;
-  border-radius: 0.25rem;
-
-  @include mobile {
-    display: none;
+  svg {
+    display: block;
   }
 }
 

--- a/styles/components/Header.module.scss
+++ b/styles/components/Header.module.scss
@@ -64,6 +64,39 @@
   }
 }
 
+.searchButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  font-family: inherit;
+  cursor: pointer;
+
+  &:hover,
+  &:active,
+  &:focus-visible {
+    color: var(--primary);
+    fill: var(--primary);
+  }
+}
+
+.kbd {
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: bold;
+  line-height: 1;
+  padding: 0.2rem 0.3rem;
+  border: 1px solid currentColor;
+  border-radius: 0.25rem;
+
+  @include mobile {
+    display: none;
+  }
+}
+
 .siteName {
   color: var(--white);
   margin: 0;


### PR DESCRIPTION
Implements TRIAGE.md item 3: a command palette (⌘K / Ctrl-K, or the header search button on touch devices) for jumping to posts, pages, and meet reports.

## How it works

- **Index**: `scripts/generate-search-index.ts` emits `public/search-index.json` (130 entries, ~3.6 KB gz, gitignored) at build time — posts and meet reports via the `lib/blogs.ts` getters (so drafts stay excluded), plus a curated page list including the `/projects/track/*` tools. Wired into `dev`, `build`, **and** `export` scripts so the static export can't ship a stale index. Shared item schema in `lib/searchIndex.ts`.
- **UI**: hand-rolled, zero-dependency Preact palette (`components/CommandPalette.tsx` + scss module). Tiered matching (substring > word-prefix > subsequence), grouped results, arrows wrap, Enter navigates (trailing-slash routes), Escape/backdrop close. Dialog/combobox/listbox ARIA with `aria-activedescendant`, Tab trapped, focus restored, body scroll locked, z-index above nprogress.
- **Loading**: the palette is its own ~2 KB gz async chunk, prefetched on first idle (`requestIdleCallback`, `setTimeout` fallback for Safari) and on header-button hover/focus; the index is fetched once and cached, with retry on failure. `next/dynamic` was deliberately avoided — its loadable runtime added +1.7 KB gz to the shared `_app` chunk; a small hand-rolled `import()`-in-effect mount keeps the shared cost at **+0.6 KB gz**.

## Testing

- `tsc --noEmit`, eslint, prettier clean; `npm run build` and `npm run export` green, with `out/search-index.json` byte-identical to `public/`'s.
- Headless Playwright against the dev server: open/toggle/close, filtering (including hyphenated queries like `wind-correction`), keyboard nav + wrap + clamp-on-shrink, Enter navigation with trailing slash, focus restore, scroll-lock restore, idle prefetch fires exactly once, 375 px viewport layout.
- Adversarially code-reviewed; all real findings fixed (panel focus stealing, ⌘K auto-repeat leaking to the browser, missing Tab trap, silent chunk-load failure, hyphenated-query matching, listbox group semantics).

Deliberate scope choices: titles + metadata only (no body-text search), no tag pages in the index (the pre-existing untrimmed-tags bug in `pages/tag/[tag].tsx` is noted in TRIAGE.md), meet reports excluded from the empty-query view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)